### PR TITLE
Add webpage summarizer chat feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# YouTube Quiz Generator
+# AI Tool Hub
 
-A Streamlit app that takes a YouTube video URL, fetches its transcript, summarizes it via OpenAI, and generates a multiple-choice quiz.
+This repository contains several Streamlit tools:
+
+- **YouTube Quiz Generator** – Paste a video URL to create a quiz from its transcript.
+- **AI Chatbot** – Chat with an AI assistant using your API key.
+- **File Chat Tool** – Upload documents and ask questions about them.
+- **Website Summarizer** – Provide a URL to get a summary and chat about that webpage.
 
 ## Setup
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-pptx
 python-docx
 PyPDF2
 streamlit-option-menu
+beautifulsoup4

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -5,6 +5,7 @@ from streamlit_option_menu import option_menu
 from youtube_quiz import run as run_youtube_quiz
 from dummy_tool1 import run as run_chatbot
 from dummy_tool2 import run as run_dummy2
+from website_summarizer import run as run_web_summarizer
 
 st.set_page_config(page_title="CWCC AI-Tool App", layout="wide", initial_sidebar_state="expanded")
 
@@ -14,8 +15,14 @@ st.set_page_config(page_title="CWCC AI-Tool App", layout="wide", initial_sidebar
 with st.sidebar:
     selected = option_menu(
         menu_title="Menue",
-        options=["Home", "YouTube Quiz Generator", "AI Chatbot", "File Chat Tool"],
-        icons=["house", "youtube", "robot", "file-earmark-text"],
+        options=[
+            "Home",
+            "YouTube Quiz Generator",
+            "AI Chatbot",
+            "File Chat Tool",
+            "Website Summarizer",
+        ],
+        icons=["house", "youtube", "robot", "file-earmark-text", "globe"],
         default_index=0,
         styles={
             "container": {"padding": "5px", "background-color": "#f0f2f6"},
@@ -95,3 +102,6 @@ elif selected == "AI Chatbot":
 
 elif selected == "File Chat Tool":
     run_dummy2()
+
+elif selected == "Website Summarizer":
+    run_web_summarizer()

--- a/website_summarizer.py
+++ b/website_summarizer.py
@@ -1,0 +1,114 @@
+import streamlit as st
+import openai
+import requests
+from bs4 import BeautifulSoup
+import traceback
+
+client = None
+MAX_CONTEXT = 100000
+
+CHUNK_SIZE = 100000
+
+def fetch_page_text(url: str) -> str:
+    try:
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+        return soup.get_text(separator="\n")
+    except Exception:
+        return ""
+
+def summarize_chunk(text: str, lang: str) -> str:
+    prompt = f"Please summarize the following webpage text in {lang}:\n\n{text}"
+    try:
+        resp = client.chat.completions.create(
+            model="Meta-Llama-4-Maverick-17B-128E-Instruct-FP8",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return resp.choices[0].message.content
+    except Exception as e:
+        st.error(f"Summarization error: {e}")
+        st.text(traceback.format_exc())
+        return ""
+
+def summarize_text(text: str, lang: str) -> str:
+    if len(text) <= CHUNK_SIZE:
+        return summarize_chunk(text, lang)
+    parts = []
+    for i in range(0, len(text), CHUNK_SIZE):
+        parts.append(summarize_chunk(text[i : i + CHUNK_SIZE], lang))
+    return summarize_chunk("\n".join(parts), lang)
+
+def run():
+    global client
+    client = openai.OpenAI(
+        api_key=st.secrets["OPENAI_API_KEY"],
+        base_url=st.secrets.get("OPENAI_BASE_URL"),
+    )
+
+    st.header("\U0001F310 Webpage Summarizer")
+    url = st.text_input("Website URL:")
+    lang = st.text_input("Language for summary:", value="English")
+
+    if "chat_history" not in st.session_state:
+        st.session_state.chat_history = []
+    if st.button("Summarize"):
+        if not url.strip():
+            st.warning("Please enter a URL.")
+            return
+        with st.spinner("Fetching webpage…"):
+            text = fetch_page_text(url.strip())
+        if not text:
+            st.error("Failed to fetch or parse the webpage.")
+            return
+        with st.spinner("Summarizing…"):
+            summary = summarize_text(text, lang.strip() or "English")
+        if summary:
+            st.session_state.page_text = text
+            st.session_state.summary = summary
+            st.session_state.chat_history = [
+                {
+                    "role": "assistant",
+                    "content": "Hi! Ask me questions about this webpage.",
+                }
+            ]
+            st.subheader("Summary")
+            st.write(summary)
+
+    if "summary" in st.session_state:
+        st.subheader("Chat About the Page")
+        if st.button("🗑️ Clear Chat"):
+            st.session_state.chat_history = [
+                {
+                    "role": "assistant",
+                    "content": "Hi! Ask me questions about this webpage.",
+                }
+            ]
+
+        for msg in st.session_state.chat_history:
+            st.chat_message(msg["role"]).write(msg["content"])
+
+        user_input = st.chat_input("Your question about the page…")
+        if user_input:
+            st.session_state.chat_history.append({"role": "user", "content": user_input})
+            st.chat_message("user").write(user_input)
+
+            system_prompt = (
+                "You are an assistant answering questions based solely on the provided webpage text. "
+                "If the answer is not contained in the text or you are uncertain, say you do not know and suggest verifying."
+            )
+            context = st.session_state.page_text[:MAX_CONTEXT]
+            messages = [{"role": "system", "content": system_prompt + "\n\n" + context}] + st.session_state.chat_history
+
+            with st.spinner("Thinking…"):
+                try:
+                    resp = client.chat.completions.create(
+                        model="Meta-Llama-4-Maverick-17B-128E-Instruct-FP8",
+                        messages=messages,
+                    )
+                    reply = resp.choices[0].message.content
+                except Exception as e:
+                    reply = f"Error: {e}"
+
+            st.session_state.chat_history.append({"role": "assistant", "content": reply})
+            st.chat_message("assistant").write(reply)


### PR DESCRIPTION
## Summary
- extend `website_summarizer.py` with a chat interface after the summary
- pre-prompt the AI to only answer using webpage content
- integrate the tool in `streamlit_app.py`
- document new feature and add `beautifulsoup4` to requirements

## Testing
- `python -m py_compile dummy_tool1.py dummy_tool2.py streamlit_app.py website_summarizer.py youtube_quiz.py`


------
https://chatgpt.com/codex/tasks/task_e_684268414e6c832ebc4fa47ec5e6112f